### PR TITLE
Return strings instead of printing

### DIFF
--- a/area4/__init__.py
+++ b/area4/__init__.py
@@ -1,7 +1,7 @@
 # ~ Area4 Package by RDIL ~ 
 
 # Package info variables:
-name = "area4" 
+name = "area4"
 author = "https://github.com/RDIL"
 author_email = "contactspaceboom@gmail.com"
 description = "Dividers in Python, the easy way! Multiple different divider looks."
@@ -19,41 +19,43 @@ divider9 = str("************************")
 divider10 = str(",,,,,,,,,,,,,,,,,,,,,,,,")
 custom_div = str("")
 
-# Functions:  
+# Functions:
 def div1():
-    print(divider1)
+    return divider1
 
 def div2():
-    print(divider2)
+    return divider2
 
 def div3():
-    print(divider3)
+    return divider3
 
 def div4():
-    print(divider4)
+    return divider4
 
 def div5():
-    print(divider5)
+    return divider5
 
 def div6():
-    print(divider6)
+    return divider6
 
 def div7():
-    print(divider7)
+    return divider7
 
 def div8():
-    print(divider8)
+    return divider8
 
 def div9():
-    print(divider9)
+    return divider9
 
 def div10():
-    print(divider10)
+    return divider10
 
 def customdiv():
-    print(custom_div)
+    return custom_div
 
 def area4info():
-    print("Name:", name)
-    print("Author:", author, "\nAuthor Email:", author_email)
-    print("Description:", description)
+    info = f"Name: {name}"
+    info += f"\nAuthor: {author}"
+    info += f"\nAuthor Email: {author_email}"
+    info += f"\nDescription: {description}"
+    return info

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -106,37 +106,37 @@ Just using plain print commands:
 
 .. code-block:: python
 
-    print(area4.divider1)  
-    print(area4.divider2)  
-    print(area4.divider3)  
-    print(area4.divider4)  
-    print(area4.divider5)  
-    print(area4.divider6)  
-    print(area4.divider7) 
-    print(area4.divider8) 
-    print(area4.divider9) 
-    print(area4.divider10) 
+    print(area4.divider1)
+    print(area4.divider2)
+    print(area4.divider3)
+    print(area4.divider4)
+    print(area4.divider5)
+    print(area4.divider6)
+    print(area4.divider7)
+    print(area4.divider8)
+    print(area4.divider9)
+    print(area4.divider10)
 
 Using functions:  
 
 .. code-block:: python
 
-    area4.div1()  
-    area4.div2()  
-    area4.div3()  
-    area4.div4()  
-    area4.div5()  
-    area4.div6()  
-    area4.div7()  
-    area4.div8()  
-    area4.div9()  
-    area4.div10()  
+    print(area4.div1())
+    print(area4.div2())
+    print(area4.div3())
+    print(area4.div4())
+    print(area4.div5())
+    print(area4.div6())
+    print(area4.div7())
+    print(area4.div8())
+    print(area4.div9())
+    print(area4.div10())
 
 And if you want to you can check to make sure the library is working:  
 
 .. code-block:: python  
 
-    area4.area4info()
+    print(area4.area4info())
  
 
 Custom Dividers  
@@ -149,12 +149,12 @@ They can be called/used/updated this way:
 .. code-block:: python  
 
     # Setting:  
-    area4.custom_div = str("dividertexthere")   
+    area4.custom_div = str("dividertexthere")
 
     # Using:  
-    area4.customdiv()  
+    print(area4.customdiv())
     # or...  
-    print(area4.custom_div)  
+    print(area4.custom_div)
 
 
 .. _here: https://repl.it/@jumbocakeyumyum/area4tests


### PR DESCRIPTION
Refactor the div and info functions to return their info for use instead of directly printing. This allows users of the module to use the dividers when and how they see fit instead of relying on the module to print directly to the console.

This PR makes the proposed changes from issue #3 